### PR TITLE
Some simple change to make ml large work

### DIFF
--- a/configs/model.py
+++ b/configs/model.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
+
 @dataclass
 class ModelConfig:
     user_cardinality: int
@@ -59,6 +60,7 @@ class TransActModuleConfig:
 class TransActModelConfig:
     transact_module_config: TransActModuleConfig
     dcnv2_config: DCNv2Config
+    user_cardinality: int
 
 
 DEFAULT_TRANSACT_MODULE_CONFIG = TransActModuleConfig(
@@ -85,6 +87,13 @@ DEFAULT_DCNV2_CONFIG = DCNv2Config(
 DEFAULT_TRANSACT_CONFIG = TransActModelConfig(
     transact_module_config=DEFAULT_TRANSACT_MODULE_CONFIG,
     dcnv2_config=DEFAULT_DCNV2_CONFIG,
+    user_cardinality=10000,
+)
+
+LARGE_TRANSACT_CONFIG = TransActModelConfig(
+    transact_module_config=DEFAULT_TRANSACT_MODULE_CONFIG,
+    dcnv2_config=DEFAULT_DCNV2_CONFIG,
+    user_cardinality=340000,
 )
 
 # Load output model path from environment variable with a default fallback

--- a/main_transact.py
+++ b/main_transact.py
@@ -1,8 +1,8 @@
 import torch
 from torch.utils.data import DataLoader
 
-from configs.model import DEFAULT_TRANSACT_CONFIG
-from data.dataset import prepare_movie_len_transact_dataset
+from configs.model import LARGE_TRANSACT_CONFIG
+from data.dataset import prepare_movie_len_transact_dataset, DatasetType
 from model.transact import TransActModule, TransAct
 from trainer.simple_trainer import SimpleTrainer
 
@@ -12,8 +12,8 @@ DEFAULT_MOVIE_LEN_EMBEDDING_PATH = "artifacts/movie_embeddings.pt"
 if __name__ == "__main__":
     embedding_store = torch.load(DEFAULT_MOVIE_LEN_EMBEDDING_PATH, weights_only=False)
 
-    model = TransAct(DEFAULT_TRANSACT_CONFIG)
-    train_dataset, eval_dataset = prepare_movie_len_transact_dataset(embedding_store=embedding_store)
+    model = TransAct(LARGE_TRANSACT_CONFIG)
+    train_dataset, eval_dataset = prepare_movie_len_transact_dataset(embedding_store=embedding_store, dataset_type=DatasetType.MOVIE_LENS_LATEST_FULL)
 
     trainer = SimpleTrainer(model=model, train_dataset=train_dataset, eval_dataset=eval_dataset)
-    trainer.train(num_epochs=5)
+    trainer.train(num_epochs=2)

--- a/model/transact.py
+++ b/model/transact.py
@@ -97,7 +97,7 @@ class TransAct(nn.Module):
         self.transact_module = TransActModule(config.transact_module_config)
         self.dcnv2 = DCNV2(config.dcnv2_config)
 
-        self.user_embedding = nn.Embedding(num_embeddings=10000, embedding_dim=32)
+        self.user_embedding = nn.Embedding(num_embeddings=config.user_cardinality, embedding_dim=32)
         self.genre_embedding = nn.Embedding(num_embeddings=32, embedding_dim=32)
 
     def forward(self, features):


### PR DESCRIPTION
### Problem
Some change to make the trainer on MovieLen large works, the primary change to to drop some rows that has insufficient seq length

### Testing
Used multi-epoch training to train the model with 5 epoches, and observed that the running loss is continuously decreasing while the evaluation AUCPR is dropping; this is a clear signal that in multi-epoch the model is overfitting; for now set epoch to 2 where we could get about 0.71 AUCPR

```
Epoch [1/5], Step [100/7153], Loss: 1.6398
Epoch [1/5], Step [200/7153], Loss: 1.6091
Epoch [1/5], Step [300/7153], Loss: 0.8309
Epoch [1/5], Step [400/7153], Loss: 0.7084
Epoch [1/5], Step [500/7153], Loss: 0.6733
Epoch [1/5], Step [600/7153], Loss: 0.6796
Epoch [1/5], Step [700/7153], Loss: 0.6662
Epoch [1/5], Step [800/7153], Loss: 0.6769
Epoch [1/5], Step [900/7153], Loss: 0.6713
Epoch [1/5], Step [1000/7153], Loss: 0.6670
Epoch [1/5], Step [1100/7153], Loss: 0.6796
Epoch [1/5], Step [1200/7153], Loss: 0.6546
Epoch [1/5], Step [1300/7153], Loss: 0.6495
Epoch [1/5], Step [1400/7153], Loss: 0.6555
Epoch [1/5], Step [1500/7153], Loss: 0.6524
Epoch [1/5], Step [1600/7153], Loss: 0.6439
Epoch [1/5], Step [1700/7153], Loss: 0.6499
Epoch [1/5], Step [1800/7153], Loss: 0.6494
Epoch [1/5], Step [1900/7153], Loss: 0.6472
Epoch [1/5], Step [2000/7153], Loss: 0.6392
Epoch [1/5], Step [2100/7153], Loss: 0.6456
Epoch [1/5], Step [2200/7153], Loss: 0.6431
Epoch [1/5], Step [2300/7153], Loss: 0.6487
Epoch [1/5], Step [2400/7153], Loss: 0.6475
Epoch [1/5], Step [2500/7153], Loss: 0.6415
Epoch [1/5], Step [2600/7153], Loss: 0.6417
Epoch [1/5], Step [2700/7153], Loss: 0.6328
Epoch [1/5], Step [2800/7153], Loss: 0.6639
Epoch [1/5], Step [2900/7153], Loss: 0.6428
Epoch [1/5], Step [3000/7153], Loss: 0.6410
Epoch [1/5], Step [3100/7153], Loss: 0.6447
Epoch [1/5], Step [3200/7153], Loss: 0.6437
Epoch [1/5], Step [3300/7153], Loss: 0.6423
Epoch [1/5], Step [3400/7153], Loss: 0.6473
Epoch [1/5], Step [3500/7153], Loss: 0.6431
Epoch [1/5], Step [3600/7153], Loss: 0.6434
Epoch [1/5], Step [3700/7153], Loss: 0.6546
Epoch [1/5], Step [3800/7153], Loss: 0.6388
Epoch [1/5], Step [3900/7153], Loss: 0.6457
Epoch [1/5], Step [4000/7153], Loss: 0.6375
Epoch [1/5], Step [4100/7153], Loss: 0.6473
Epoch [1/5], Step [4200/7153], Loss: 0.6914
Epoch [1/5], Step [4300/7153], Loss: 0.6341
Epoch [1/5], Step [4400/7153], Loss: 0.6425
Epoch [1/5], Step [4500/7153], Loss: 0.6432
Epoch [1/5], Step [4600/7153], Loss: 0.6365
Epoch [1/5], Step [4700/7153], Loss: 0.6424
Epoch [1/5], Step [4800/7153], Loss: 0.6427
Epoch [1/5], Step [4900/7153], Loss: 0.6449
Epoch [1/5], Step [5000/7153], Loss: 0.6370
Epoch [1/5], Step [5100/7153], Loss: 0.6251
Epoch [1/5], Step [5200/7153], Loss: 0.6423
Epoch [1/5], Step [5300/7153], Loss: 0.6337
Epoch [1/5], Step [5400/7153], Loss: 0.6550
Epoch [1/5], Step [5500/7153], Loss: 0.6454
Epoch [1/5], Step [5600/7153], Loss: 0.6426
Epoch [1/5], Step [5700/7153], Loss: 0.6311
Epoch [1/5], Step [5800/7153], Loss: 0.6416
Epoch [1/5], Step [5900/7153], Loss: 0.6364
Epoch [1/5], Step [6000/7153], Loss: 0.6466
Epoch [1/5], Step [6100/7153], Loss: 0.6374
Epoch [1/5], Step [6200/7153], Loss: 0.6425
Epoch [1/5], Step [6300/7153], Loss: 0.6370
Epoch [1/5], Step [6400/7153], Loss: 0.6538
Epoch [1/5], Step [6500/7153], Loss: 0.6464
Epoch [1/5], Step [6600/7153], Loss: 0.6506
Epoch [1/5], Step [6700/7153], Loss: 0.6455
Epoch [1/5], Step [6800/7153], Loss: 0.6518
Epoch [1/5], Step [6900/7153], Loss: 0.6407
Epoch [1/5], Step [7000/7153], Loss: 0.6431
Epoch [1/5], Step [7100/7153], Loss: 0.6359
Start evaluation
Aucpr: 0.7048
Epoch [2/5], Step [100/7153], Loss: 0.6383
Epoch [2/5], Step [200/7153], Loss: 0.6414
Epoch [2/5], Step [300/7153], Loss: 0.6366
Epoch [2/5], Step [400/7153], Loss: 0.6393
Epoch [2/5], Step [500/7153], Loss: 0.6434
Epoch [2/5], Step [600/7153], Loss: 0.6402
Epoch [2/5], Step [700/7153], Loss: 0.6291
Epoch [2/5], Step [800/7153], Loss: 0.6372
Epoch [2/5], Step [900/7153], Loss: 0.6463
Epoch [2/5], Step [1000/7153], Loss: 0.6353
Epoch [2/5], Step [1100/7153], Loss: 0.6366
Epoch [2/5], Step [1200/7153], Loss: 0.6437
Epoch [2/5], Step [1300/7153], Loss: 0.6344
Epoch [2/5], Step [1400/7153], Loss: 0.6421
Epoch [2/5], Step [1500/7153], Loss: 0.6401
Epoch [2/5], Step [1600/7153], Loss: 0.6218
Epoch [2/5], Step [1700/7153], Loss: 0.6273
Epoch [2/5], Step [1800/7153], Loss: 0.6392
Epoch [2/5], Step [1900/7153], Loss: 0.6313
Epoch [2/5], Step [2000/7153], Loss: 0.6310
Epoch [2/5], Step [2100/7153], Loss: 0.6339
Epoch [2/5], Step [2200/7153], Loss: 0.6368
Epoch [2/5], Step [2300/7153], Loss: 0.6376
Epoch [2/5], Step [2400/7153], Loss: 0.6353
Epoch [2/5], Step [2500/7153], Loss: 0.6353
Epoch [2/5], Step [2600/7153], Loss: 0.6364
Epoch [2/5], Step [2700/7153], Loss: 0.6300
Epoch [2/5], Step [2800/7153], Loss: 0.6560
Epoch [2/5], Step [2900/7153], Loss: 0.6342
Epoch [2/5], Step [3000/7153], Loss: 0.6286
Epoch [2/5], Step [3100/7153], Loss: 0.6301
Epoch [2/5], Step [3200/7153], Loss: 0.6306
Epoch [2/5], Step [3300/7153], Loss: 0.6286
Epoch [2/5], Step [3400/7153], Loss: 0.6297
Epoch [2/5], Step [3500/7153], Loss: 0.6271
Epoch [2/5], Step [3600/7153], Loss: 0.6366
Epoch [2/5], Step [3700/7153], Loss: 0.6481
Epoch [2/5], Step [3800/7153], Loss: 0.6309
Epoch [2/5], Step [3900/7153], Loss: 0.6453
Epoch [2/5], Step [4000/7153], Loss: 0.6332
Epoch [2/5], Step [4100/7153], Loss: 0.6590
Epoch [2/5], Step [4200/7153], Loss: 0.6474
Epoch [2/5], Step [4300/7153], Loss: 0.6327
Epoch [2/5], Step [4400/7153], Loss: 0.6373
Epoch [2/5], Step [4500/7153], Loss: 0.6337
Epoch [2/5], Step [4600/7153], Loss: 0.6294
Epoch [2/5], Step [4700/7153], Loss: 0.6376
Epoch [2/5], Step [4800/7153], Loss: 0.6303
Epoch [2/5], Step [4900/7153], Loss: 0.6383
Epoch [2/5], Step [5000/7153], Loss: 0.6307
Epoch [2/5], Step [5100/7153], Loss: 0.6108
Epoch [2/5], Step [5200/7153], Loss: 0.6253
Epoch [2/5], Step [5300/7153], Loss: 0.6290
Epoch [2/5], Step [5400/7153], Loss: 0.6491
Epoch [2/5], Step [5500/7153], Loss: 0.6338
Epoch [2/5], Step [5600/7153], Loss: 0.6373
Epoch [2/5], Step [5700/7153], Loss: 0.6226
Epoch [2/5], Step [5800/7153], Loss: 0.6350
Epoch [2/5], Step [5900/7153], Loss: 0.6247
Epoch [2/5], Step [6000/7153], Loss: 0.6407
Epoch [2/5], Step [6100/7153], Loss: 0.6273
Epoch [2/5], Step [6200/7153], Loss: 0.6358
Epoch [2/5], Step [6300/7153], Loss: 0.6284
Epoch [2/5], Step [6400/7153], Loss: 0.6356
Epoch [2/5], Step [6500/7153], Loss: 0.6348
Epoch [2/5], Step [6600/7153], Loss: 0.6409
Epoch [2/5], Step [6700/7153], Loss: 0.6303
Epoch [2/5], Step [6800/7153], Loss: 0.6355
Epoch [2/5], Step [6900/7153], Loss: 0.6270
Epoch [2/5], Step [7000/7153], Loss: 0.6372
Epoch [2/5], Step [7100/7153], Loss: 0.6293
Start evaluation
Aucpr: 0.7134
Epoch [3/5], Step [100/7153], Loss: 0.6288
Epoch [3/5], Step [200/7153], Loss: 0.6309
Epoch [3/5], Step [300/7153], Loss: 0.6218
Epoch [3/5], Step [400/7153], Loss: 0.6299
Epoch [3/5], Step [500/7153], Loss: 0.6301
Epoch [3/5], Step [600/7153], Loss: 0.6292
Epoch [3/5], Step [700/7153], Loss: 0.6159
Epoch [3/5], Step [800/7153], Loss: 0.6287
Epoch [3/5], Step [900/7153], Loss: 0.6381
Epoch [3/5], Step [1000/7153], Loss: 0.6233
Epoch [3/5], Step [1100/7153], Loss: 0.6134
Epoch [3/5], Step [1200/7153], Loss: 0.6202
Epoch [3/5], Step [1300/7153], Loss: 0.6099
Epoch [3/5], Step [1400/7153], Loss: 0.6164
Epoch [3/5], Step [1500/7153], Loss: 0.6115
Epoch [3/5], Step [1600/7153], Loss: 0.5972
Epoch [3/5], Step [1700/7153], Loss: 0.5964
Epoch [3/5], Step [1800/7153], Loss: 0.6080
Epoch [3/5], Step [1900/7153], Loss: 0.6042
Epoch [3/5], Step [2000/7153], Loss: 0.6074
Epoch [3/5], Step [2100/7153], Loss: 0.6052
Epoch [3/5], Step [2200/7153], Loss: 0.6157
Epoch [3/5], Step [2300/7153], Loss: 0.6123
Epoch [3/5], Step [2400/7153], Loss: 0.6136
Epoch [3/5], Step [2500/7153], Loss: 0.6062
Epoch [3/5], Step [2600/7153], Loss: 0.6091
Epoch [3/5], Step [2700/7153], Loss: 0.5947
Epoch [3/5], Step [2800/7153], Loss: 0.6298
Epoch [3/5], Step [2900/7153], Loss: 0.6010
Epoch [3/5], Step [3000/7153], Loss: 0.5968
Epoch [3/5], Step [3100/7153], Loss: 0.6016
Epoch [3/5], Step [3200/7153], Loss: 0.5966
Epoch [3/5], Step [3300/7153], Loss: 0.6026
Epoch [3/5], Step [3400/7153], Loss: 0.5997
Epoch [3/5], Step [3500/7153], Loss: 0.5936
Epoch [3/5], Step [3600/7153], Loss: 0.6126
Epoch [3/5], Step [3700/7153], Loss: 0.6000
Epoch [3/5], Step [3800/7153], Loss: 0.5875
Epoch [3/5], Step [3900/7153], Loss: 0.5990
Epoch [3/5], Step [4000/7153], Loss: 0.6001
Epoch [3/5], Step [4100/7153], Loss: 0.6097
Epoch [3/5], Step [4200/7153], Loss: 0.6149
Epoch [3/5], Step [4300/7153], Loss: 0.6016
Epoch [3/5], Step [4400/7153], Loss: 0.6052
Epoch [3/5], Step [4500/7153], Loss: 0.6082
Epoch [3/5], Step [4600/7153], Loss: 0.5947
Epoch [3/5], Step [4700/7153], Loss: 0.6075
Epoch [3/5], Step [4800/7153], Loss: 0.5995
Epoch [3/5], Step [4900/7153], Loss: 0.6084
Epoch [3/5], Step [5000/7153], Loss: 0.6020
Epoch [3/5], Step [5100/7153], Loss: 0.5760
Epoch [3/5], Step [5200/7153], Loss: 0.5910
Epoch [3/5], Step [5300/7153], Loss: 0.5991
Epoch [3/5], Step [5400/7153], Loss: 0.6198
Epoch [3/5], Step [5500/7153], Loss: 0.6009
Epoch [3/5], Step [5600/7153], Loss: 0.6069
Epoch [3/5], Step [5700/7153], Loss: 0.5907
Epoch [3/5], Step [5800/7153], Loss: 0.6149
Epoch [3/5], Step [5900/7153], Loss: 0.5950
Epoch [3/5], Step [6000/7153], Loss: 0.6078
Epoch [3/5], Step [6100/7153], Loss: 0.6111
Epoch [3/5], Step [6200/7153], Loss: 0.6089
Epoch [3/5], Step [6300/7153], Loss: 0.5971
Epoch [3/5], Step [6400/7153], Loss: 0.6026
Epoch [3/5], Step [6500/7153], Loss: 0.5976
Epoch [3/5], Step [6600/7153], Loss: 0.6055
Epoch [3/5], Step [6700/7153], Loss: 0.5912
Epoch [3/5], Step [6800/7153], Loss: 0.5986
Epoch [3/5], Step [6900/7153], Loss: 0.5903
Epoch [3/5], Step [7000/7153], Loss: 0.6048
Epoch [3/5], Step [7100/7153], Loss: 0.5973
Start evaluation
Aucpr: 0.6844
Epoch [4/5], Step [100/7153], Loss: 0.5994
Epoch [4/5], Step [200/7153], Loss: 0.5975
Epoch [4/5], Step [300/7153], Loss: 0.5874
Epoch [4/5], Step [400/7153], Loss: 0.6020
Epoch [4/5], Step [500/7153], Loss: 0.6024
Epoch [4/5], Step [600/7153], Loss: 0.5993
Epoch [4/5], Step [700/7153], Loss: 0.5862
Epoch [4/5], Step [800/7153], Loss: 0.5959
Epoch [4/5], Step [900/7153], Loss: 0.5986
Epoch [4/5], Step [1000/7153], Loss: 0.5801
Epoch [4/5], Step [1100/7153], Loss: 0.5729
Epoch [4/5], Step [1200/7153], Loss: 0.5676
Epoch [4/5], Step [1300/7153], Loss: 0.5577
Epoch [4/5], Step [1400/7153], Loss: 0.5656
Epoch [4/5], Step [1500/7153], Loss: 0.5595
Epoch [4/5], Step [1600/7153], Loss: 0.5434
Epoch [4/5], Step [1700/7153], Loss: 0.5459
Epoch [4/5], Step [1800/7153], Loss: 0.5493
Epoch [4/5], Step [1900/7153], Loss: 0.5466
Epoch [4/5], Step [2000/7153], Loss: 0.5550
Epoch [4/5], Step [2100/7153], Loss: 0.5557
Epoch [4/5], Step [2200/7153], Loss: 0.5685
Epoch [4/5], Step [2300/7153], Loss: 0.5701
Epoch [4/5], Step [2400/7153], Loss: 0.5599
Epoch [4/5], Step [2500/7153], Loss: 0.5618
Epoch [4/5], Step [2600/7153], Loss: 0.5597
Epoch [4/5], Step [2700/7153], Loss: 0.5347
Epoch [4/5], Step [2800/7153], Loss: 0.5718
Epoch [4/5], Step [2900/7153], Loss: 0.5412
Epoch [4/5], Step [3000/7153], Loss: 0.5510
Epoch [4/5], Step [3100/7153], Loss: 0.5412
Epoch [4/5], Step [3200/7153], Loss: 0.5318
Epoch [4/5], Step [3300/7153], Loss: 0.5482
Epoch [4/5], Step [3400/7153], Loss: 0.5423
Epoch [4/5], Step [3500/7153], Loss: 0.5362
Epoch [4/5], Step [3600/7153], Loss: 0.5511
Epoch [4/5], Step [3700/7153], Loss: 0.5397
Epoch [4/5], Step [3800/7153], Loss: 0.5215
Epoch [4/5], Step [3900/7153], Loss: 0.5362
Epoch [4/5], Step [4000/7153], Loss: 0.5464
Epoch [4/5], Step [4100/7153], Loss: 0.5465
Epoch [4/5], Step [4200/7153], Loss: 0.5541
Epoch [4/5], Step [4300/7153], Loss: 0.5473
Epoch [4/5], Step [4400/7153], Loss: 0.5492
Epoch [4/5], Step [4500/7153], Loss: 0.5483
Epoch [4/5], Step [4600/7153], Loss: 0.5374
Epoch [4/5], Step [4700/7153], Loss: 0.5543
Epoch [4/5], Step [4800/7153], Loss: 0.5365
Epoch [4/5], Step [4900/7153], Loss: 0.5526
Epoch [4/5], Step [5000/7153], Loss: 0.5427
Epoch [4/5], Step [5100/7153], Loss: 0.5198
Epoch [4/5], Step [5200/7153], Loss: 0.5634
Epoch [4/5], Step [5300/7153], Loss: 0.5415
Epoch [4/5], Step [5400/7153], Loss: 0.5584
Epoch [4/5], Step [5500/7153], Loss: 0.5453
Epoch [4/5], Step [5600/7153], Loss: 0.5535
Epoch [4/5], Step [5700/7153], Loss: 0.5314
Epoch [4/5], Step [5800/7153], Loss: 0.5599
Epoch [4/5], Step [5900/7153], Loss: 0.5290
Epoch [4/5], Step [6000/7153], Loss: 0.5499
Epoch [4/5], Step [6100/7153], Loss: 0.5463
Epoch [4/5], Step [6200/7153], Loss: 0.5528
Epoch [4/5], Step [6300/7153], Loss: 0.5386
Epoch [4/5], Step [6400/7153], Loss: 0.5476
Epoch [4/5], Step [6500/7153], Loss: 0.5437
Epoch [4/5], Step [6600/7153], Loss: 0.5499
Epoch [4/5], Step [6700/7153], Loss: 0.5320
Epoch [4/5], Step [6800/7153], Loss: 0.5391
Epoch [4/5], Step [6900/7153], Loss: 0.5281
Epoch [4/5], Step [7000/7153], Loss: 0.5474
Epoch [4/5], Step [7100/7153], Loss: 0.5415
Start evaluation
Aucpr: 0.6646
Epoch [5/5], Step [100/7153], Loss: 0.5432
Epoch [5/5], Step [200/7153], Loss: 0.5463
Epoch [5/5], Step [300/7153], Loss: 0.5326
Epoch [5/5], Step [400/7153], Loss: 0.5473
Epoch [5/5], Step [500/7153], Loss: 0.5447
Epoch [5/5], Step [600/7153], Loss: 0.5356
Epoch [5/5], Step [700/7153], Loss: 0.5264
Epoch [5/5], Step [800/7153], Loss: 0.5415
Epoch [5/5], Step [900/7153], Loss: 0.5411
Epoch [5/5], Step [1000/7153], Loss: 0.5123
Epoch [5/5], Step [1100/7153], Loss: 0.5326
Epoch [5/5], Step [1200/7153], Loss: 0.4873
Epoch [5/5], Step [1300/7153], Loss: 0.4822
Epoch [5/5], Step [1400/7153], Loss: 0.4833
Epoch [5/5], Step [1500/7153], Loss: 0.4795
Epoch [5/5], Step [1600/7153], Loss: 0.4750
Epoch [5/5], Step [1700/7153], Loss: 0.4666
Epoch [5/5], Step [1800/7153], Loss: 0.4702
Epoch [5/5], Step [1900/7153], Loss: 0.4720
Epoch [5/5], Step [2000/7153], Loss: 0.4825
Epoch [5/5], Step [2100/7153], Loss: 0.4894
Epoch [5/5], Step [2200/7153], Loss: 0.5025
Epoch [5/5], Step [2300/7153], Loss: 0.4916
Epoch [5/5], Step [2400/7153], Loss: 0.4864
Epoch [5/5], Step [2500/7153], Loss: 0.4775
Epoch [5/5], Step [2600/7153], Loss: 0.4850
Epoch [5/5], Step [2700/7153], Loss: 0.4573
Epoch [5/5], Step [2800/7153], Loss: 0.4940
Epoch [5/5], Step [2900/7153], Loss: 0.4632
Epoch [5/5], Step [3000/7153], Loss: 0.4664
Epoch [5/5], Step [3100/7153], Loss: 0.4609
Epoch [5/5], Step [3200/7153], Loss: 0.4490
Epoch [5/5], Step [3300/7153], Loss: 0.4675
Epoch [5/5], Step [3400/7153], Loss: 0.4591
Epoch [5/5], Step [3500/7153], Loss: 0.4616
Epoch [5/5], Step [3600/7153], Loss: 0.4806
Epoch [5/5], Step [3700/7153], Loss: 0.4591
Epoch [5/5], Step [3800/7153], Loss: 0.4371
Epoch [5/5], Step [3900/7153], Loss: 0.4560
Epoch [5/5], Step [4000/7153], Loss: 0.4769
Epoch [5/5], Step [4100/7153], Loss: 0.4807
Epoch [5/5], Step [4200/7153], Loss: 0.4770
Epoch [5/5], Step [4300/7153], Loss: 0.4735
Epoch [5/5], Step [4400/7153], Loss: 0.4761
Epoch [5/5], Step [4500/7153], Loss: 0.4629
Epoch [5/5], Step [4600/7153], Loss: 0.4605
Epoch [5/5], Step [4700/7153], Loss: 0.4823
Epoch [5/5], Step [4800/7153], Loss: 0.4507
Epoch [5/5], Step [4900/7153], Loss: 0.4724
Epoch [5/5], Step [5000/7153], Loss: 0.4619
Epoch [5/5], Step [5100/7153], Loss: 0.4388
Epoch [5/5], Step [5200/7153], Loss: 0.4623
Epoch [5/5], Step [5300/7153], Loss: 0.4670
Epoch [5/5], Step [5400/7153], Loss: 0.4778
Epoch [5/5], Step [5500/7153], Loss: 0.4585
Epoch [5/5], Step [5600/7153], Loss: 0.4718
Epoch [5/5], Step [5700/7153], Loss: 0.4479
Epoch [5/5], Step [5800/7153], Loss: 0.4831
Epoch [5/5], Step [5900/7153], Loss: 0.4457
Epoch [5/5], Step [6000/7153], Loss: 0.4685
Epoch [5/5], Step [6100/7153], Loss: 0.4663
Epoch [5/5], Step [6200/7153], Loss: 0.4731
Epoch [5/5], Step [6300/7153], Loss: 0.4614
Epoch [5/5], Step [6400/7153], Loss: 0.4682
Epoch [5/5], Step [6500/7153], Loss: 0.4627
Epoch [5/5], Step [6600/7153], Loss: 0.4733
Epoch [5/5], Step [6700/7153], Loss: 0.4514
Epoch [5/5], Step [6800/7153], Loss: 0.4594
Epoch [5/5], Step [6900/7153], Loss: 0.4449
Epoch [5/5], Step [7000/7153], Loss: 0.4640
Epoch [5/5], Step [7100/7153], Loss: 0.4586
Start evaluation
Aucpr: 0.6365
Simple trainer finished training
```