### PR TITLE
Bug fix

### DIFF
--- a/main_transact.py
+++ b/main_transact.py
@@ -12,7 +12,9 @@ if __name__ == "__main__":
     embedding_store = torch.load(DEFAULT_MOVIE_LEN_EMBEDDING_PATH, weights_only=False)
 
     model = TransAct(LARGE_TRANSACT_CONFIG)
-    train_dataset, eval_dataset = prepare_movie_len_transact_dataset(embedding_store=embedding_store, dataset_type=DatasetType.MOVIE_LENS_LATEST_FULL)
+    train_dataset, eval_dataset = prepare_movie_len_transact_dataset(embedding_store=embedding_store, 
+                                                                     dataset_type=DatasetType.MOVIE_LENS_LATEST_FULL,
+                                                                     history_seq_length=15)
 
     trainer = SimpleTrainer(model=model, train_dataset=train_dataset, eval_dataset=eval_dataset)
     trainer.train(num_epochs=2)

--- a/trainer/embedding_trainer.py
+++ b/trainer/embedding_trainer.py
@@ -65,7 +65,7 @@ class EmbeddingTrainer:
                 item_ids = item_ids.to(self.device)
                 ratings = ratings.to(self.device)
 
-                predictions = self.model(user_ids, item_ids)
+                predictions = self.model(user_ids, item_ids).squeeze(1)
                 loss = self.loss(predictions, ratings)
 
                 total_loss += loss.item()


### PR DESCRIPTION
### Problem
Fix some bug and rerun the transact model training

1. re-generate the item embedding due to pervious bug in the two tower model
2. fix one issue in the transact model training
3. fix one issue in the two tower model that evaluation is not computed correctly; the model predictions is in shape [B, 1] while the label is in [B,], this would cause issue when use MSE loss because of broadcasting is right aligned, and the result loss matrix would be in [B, B] which double the actual loss

### Testing done
Start evaluation
Aucpr: 0.7315
Simple trainer finished training