### PR TITLE
[3/X] Integrate duckdb ebr engine into inference server

### DIFF
--- a/server/duckdb_ebr_server.py
+++ b/server/duckdb_ebr_server.py
@@ -4,6 +4,7 @@ import os
 import duckdb
 
 from configs.model import OUTPUT_MODEL_PATH
+import proto.ebr_pb2
 
 
 class DuckEBRServer:
@@ -69,7 +70,9 @@ class DuckEBRServer:
             if next_index < len(indices[array_index]):  # check if we have consumed all elements in this array
                 heapq.heappush(heap, (distances[array_index][next_index], array_index, next_index))
 
-        return result
+        # To make the interface consistent, we reuse the entity we have define in protobuf for ebr server
+        return [proto.ebr_pb2.SearchResult(
+                id=c["id"], score=c["score"], source_id=c["source_id"]) for c in result]
 
 if __name__ == "__main__":
     server = DuckEBRServer()

--- a/server/inference_engine.py
+++ b/server/inference_engine.py
@@ -28,7 +28,7 @@ feature_server = FeatureServer(
     FeatureServerConfig(movie_len_history_seq_length=15, movie_len_dataset_type=DatasetType.MOVIE_LENS_LATEST_FULL, embedding_store_path="artifacts/movie_embeddings.pt")
 )
 retrieval_engine = RetrievalEngine(
-    RetrievalEngineConfig(enable_embedding_retrieval_engine=True, num_candidates=10),
+    RetrievalEngineConfig(enable_duckdb_retrieval_engine=True, num_candidates=10),
     feature_server,
 )
 


### PR DESCRIPTION
### Problem

Integrate the DuckDB EBR into the inference engine

### Testing done
<img width="1480" alt="Screenshot 2025-05-31 at 8 59 12 AM" src="https://github.com/user-attachments/assets/a89f8613-11be-4f17-9369-ac42f031d9ec" />

The recommendation generated is pretty different from the pervious FAISS one, which might due to the different distance metrics used for indexing; for next step, I plan to add a simple visualization to quality evaluate the result