### PR TITLE
[4/X] Add gumble sample for codebook update

### DIFF
--- a/movie_len_rq_vae.py
+++ b/movie_len_rq_vae.py
@@ -6,6 +6,11 @@ from model.rqvae import RQVAE
 from trainer.rqvae_trainer import RQVAETrainer
 
 
+def count_codebook_usage(indices, codebook_size):
+    usage_counts = torch.bincount(indices, minlength=codebook_size)
+    return usage_counts
+
+
 if __name__ == "__main__":
     train_dataset = MovieLenSemanticEmbeddingDataset()
     train_loader = DataLoader(train_dataset, batch_size=128, shuffle=True)
@@ -14,11 +19,15 @@ if __name__ == "__main__":
     trainer = RQVAETrainer(model=model, data_loader=train_loader)
     trainer.train(num_epochs=1)
 
-    # Add some simple test
+    # Add some simple test to count the codebook usage
+    # by default, the codebook size is 32, number of codebook is 3, just use cpu to count the usage
+    codebook_counters = {i: torch.zeros(32) for i in range(3)}
     model.to("cpu")
     model.eval()
-    test_data = train_dataset[0:30]
-    test_data = test_data.to("cpu")
 
-    _, ind = model(test_data)
-    print(ind)
+    test_loader = DataLoader(train_dataset, batch_size=128, shuffle=False)
+    for batch in test_loader:
+        _, ind = model(batch)  # ind is a list of 3 tensors
+        for i, ind_i in enumerate(ind):
+            codebook_counters[i] += count_codebook_usage(ind_i, 32)
+    print(codebook_counters)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ fastapi
 grpcio
 grpcio-tools
 jsonlines
+k-means-constrained
 pandas
 pyarrow
 python-dotenv


### PR DESCRIPTION
### Problem

The original codebook update is using STE which might not optimal; use the gumbel softmax to simulate the gradient for topk operation

### Testing done
The distribution of the codebook get slightly better
```
{0: tensor([0.0000e+00, 3.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 0.0000e+00, 0.0000e+00, 2.5290e+03, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 0.0000e+00, 1.0492e+04, 0.0000e+00, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 7.1439e+04, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 1.9000e+01]), 1: tensor([8.0500e+02, 0.0000e+00, 3.1200e+02, 0.0000e+00, 4.6760e+03, 0.0000e+00,
        0.0000e+00, 0.0000e+00, 7.6180e+03, 0.0000e+00, 3.2180e+03, 0.0000e+00,
        1.2520e+03, 2.9834e+04, 3.9000e+03, 9.8680e+03, 0.0000e+00, 1.7400e+03,
        6.0240e+03, 2.3000e+01, 0.0000e+00, 0.0000e+00, 0.0000e+00, 0.0000e+00,
        0.0000e+00, 0.0000e+00, 0.0000e+00, 1.5027e+04, 0.0000e+00, 1.8500e+02,
        0.0000e+00, 0.0000e+00]), 2: tensor([9.1000e+01, 5.0000e+00, 4.0000e+00, 9.2000e+01, 5.2530e+03, 0.0000e+00,
        1.9000e+01, 1.0000e+00, 0.0000e+00, 2.0000e+00, 6.9200e+02, 5.2000e+01,
        1.2200e+02, 8.0000e+00, 0.0000e+00, 7.7300e+02, 3.0000e+00, 1.4300e+02,
        2.2400e+02, 0.0000e+00, 3.2400e+02, 4.1000e+01, 0.0000e+00, 1.1000e+01,
        4.2000e+01, 7.0000e+00, 2.0000e+00, 6.5221e+04, 1.9000e+01, 1.1301e+04,
        3.0000e+01, 0.0000e+00])}
```